### PR TITLE
Use `alr test` instead of `alr get --build`

### DIFF
--- a/scripts/gh-build-crate.sh
+++ b/scripts/gh-build-crate.sh
@@ -208,11 +208,20 @@ for file in $CHANGES; do
       echo BUILD ENVIRONMENT
       alr printenv
 
-      echo BUILDING CRATE
-      alr build --release
-      # As normally dependencies/executables are built in release mode, we also
-      # check any submissions in this mode. Should we go overboard and check the
-      # three profile modes?
+      # To test, we use the regular `alr test`, reusing the download. In ths way,
+      # crates providing a test action may succeed even if not intended to be
+      # build directly.
+      echo TESTING CRATE
+      cd ..
+      alr test --redo $milestone
+
+      # Re-enter the deployment dir
+      cd $(alr get --dirname $milestone)
+
+      echo TEST LOG
+      echo ---8<---
+      cat alire/alr_test_*.log
+      echo ---8<---
 
       echo LISTING EXECUTABLES of crate $milestone
       alr run --list

--- a/scripts/gh-build-crate.sh
+++ b/scripts/gh-build-crate.sh
@@ -219,9 +219,9 @@ for file in $CHANGES; do
       cd $(alr get --dirname $milestone)
 
       echo TEST LOG
-      echo ---8<---
+      echo '---8<---'
       cat alire/alr_test_*.log
-      echo ---8<---
+      echo '---8<---'
 
       echo LISTING EXECUTABLES of crate $milestone
       alr run --list


### PR DESCRIPTION
Some crates can never succeed with `alr get --build`. With this change, as long as such crates provide a test action, they can be properly tested.