### PR TITLE
Replace `which` with bash internal `type`

### DIFF
--- a/scripts/gh-build-crate.sh
+++ b/scripts/gh-build-crate.sh
@@ -19,8 +19,8 @@ alias alr="alr -d -n"
 
 # Configure `sh` to be Bourne-compatible or some `configure` scripts may fail
 [ `uname -s` == "Linux" ] && {
-   sudo ln -fs $(which bash) /bin/sh
-   sudo ln -fs $(which bash) /usr/bin/sh
+   sudo ln -fs $(type -p bash) /bin/sh
+   sudo ln -fs $(type -p bash) /usr/bin/sh
    echo Configured Bash as default shell system-wide
 }
 


### PR DESCRIPTION
This ensures success even in platforms without `which` available by default, like Arch.