### PR TITLE
add script for website field check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ on:
 
 env:
   CHECKS_REPO: .
+  PACMAN: C:\Users\runneradmin\AppData\Local\alire\cache\msys64\usr\bin\pacman
 
 jobs:
 
@@ -41,7 +42,7 @@ jobs:
 
     - name: Install tar from msys2 (Windows) # Git tar in Actions VM does not seem to work)
       if: matrix.os == 'windows-latest'
-      run: C:\Users\runneradmin\.cache\alire\msys64\usr\bin\pacman --noconfirm -S tar
+      run: ${{env.PACMAN}} --noconfirm -S tar
 
     # Test all crates found in the index, as we want to verify checks for all kinds of
     # crates still work when checks are modified.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,12 +30,12 @@ jobs:
     # By default, this sets up the newest indexed native toolchain
     - name: Set up stable `alr`
       if: contains(github.base_ref, 'stable-')
-      uses: alire-project/setup-alire@v2
+      uses: alire-project/setup-alire@v5
 
     # By default, this sets up the newest indexed native toolchain
     - name: Set up devel `alr`
       if: contains(github.base_ref, 'devel-')
-      uses: alire-project/setup-alire@v2
+      uses: alire-project/setup-alire@v5
       with:
         branch: 'master'
 

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,0 +1,31 @@
+name: Website
+# Check manifest has a website field
+
+on:
+  pull_request:
+
+env:
+  CHECKS_REPO: .
+
+jobs:
+
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Set up `alr`
+      uses: alire-project/setup-alire@v2
+      with:
+        version: nightly
+        toolchain: --disable-assistant # no need for it
+
+    - name: Test crates
+      run: ${{env.CHECKS_REPO}}/scripts/check-website.sh
+      shell: bash
+      env:
+        DRY_RUN: TRUE

--- a/index/gn/gnat_native/gnat_native-13.2.2.toml
+++ b/index/gn/gnat_native/gnat_native-13.2.2.toml
@@ -1,0 +1,36 @@
+
+name = "gnat_native"
+version = "13.2.2"
+provides = ["gnat=13.2.2"]
+description = "The GNAT Ada compiler - Native"
+maintainers = ["chouteau@adacore.com"]
+maintainers-logins = ["Fabien-Chouteau"]
+licenses = "GPL-3.0-or-later AND GPL-3.0-or-later WITH GCC-exception-3.1"
+
+auto-gpr-with = false
+
+[configuration]
+disabled = true
+
+[environment]
+PATH.prepend = "${CRATE_ROOT}/bin"
+
+[origin."case(os)".linux."case(host-arch)".x86-64]
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-13.2.0-2/gnat-x86_64-linux-13.2.0-2.tar.gz"
+hashes = ["sha256:a27fd7945ac9ead50abdd8e4564d133d00f635536bf9dfdf1e00af5e08a0c494"]
+binary = true
+
+[origin."case(os)".windows."case(host-arch)".x86-64]
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-13.2.0-2/gnat-x86_64-windows64-13.2.0-2.tar.gz"
+hashes = ["sha256:88799c95aedc8a50627c9705ff8c60f78941312c86459352bc88f47786466d23"]
+binary = true
+
+[origin."case(os)".macos."case(host-arch)".x86-64]
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-13.2.0-2/gnat-x86_64-darwin-13.2.0-2.tar.gz"
+hashes = ["sha256:9be96041c0c280d5c78cf3e66ced84203354773f68240cc0f03b087ee109d2b0"]
+binary = true
+
+[origin."case(os)".macos."case(host-arch)".aarch64]
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-13.2.0-2/gnat-aarch64-darwin-13.2.0-2.tar.gz"
+hashes = ["sha256:b2c113d5ac9301e1abc37a45e1f825fe4cb1cb16fbba606fdfe339012ad7a000"]
+binary = true

--- a/index/gn/gnat_native/gnat_native-14.2.1.toml
+++ b/index/gn/gnat_native/gnat_native-14.2.1.toml
@@ -1,0 +1,56 @@
+
+name = "gnat_native"
+version = "14.2.1"
+provides = ["gnat=14.2.1"]
+description = "The GNAT Ada compiler - Native"
+maintainers = ["chouteau@adacore.com"]
+maintainers-logins = ["Fabien-Chouteau"]
+licenses = "GPL-3.0-or-later AND GPL-3.0-or-later WITH GCC-exception-3.1"
+
+auto-gpr-with = false
+
+[configuration]
+disabled = true
+
+[environment."case(os)".linux]
+PATH.prepend = "${CRATE_ROOT}/bin"
+LIBRARY_PATH.prepend = "${CRATE_ROOT}/lib64"
+LD_LIBRARY_PATH.prepend = "${CRATE_ROOT}/lib64"
+LD_RUN_PATH.prepend = "${CRATE_ROOT}/lib64"
+
+[environment."case(os)".windows."case(host-arch)".x86-64]
+PATH.prepend = "${CRATE_ROOT}/bin"
+LIBRARY_PATH.prepend = "${CRATE_ROOT}/lib"
+LD_LIBRARY_PATH.prepend = "${CRATE_ROOT}/lib"
+LD_RUN_PATH.prepend = "${CRATE_ROOT}/lib"
+
+[environment."case(os)".macos]
+PATH.prepend = "${CRATE_ROOT}/bin"
+LIBRARY_PATH.prepend = "${CRATE_ROOT}/lib"
+LD_LIBRARY_PATH.prepend = "${CRATE_ROOT}/lib"
+LD_RUN_PATH.prepend = "${CRATE_ROOT}/lib"
+
+[origin."case(os)".linux."case(host-arch)".x86-64]
+binary = true
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-14.2.0-1/gnat-x86_64-linux-14.2.0-1.tar.gz"
+hashes = ["sha256:06bb3def7f70371d601a5c8b93bc4933c50873a5e5ba26aa7ee3447dda687722"]
+
+[origin."case(os)".linux."case(host-arch)".aarch64]
+binary = true
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-14.2.0-1/gnat-aarch64-linux-14.2.0-1.tar.gz"
+hashes = ["sha256:a28acec19866f46135594d7a1c6cca6085396598a256d03a4d01d8cb83f517dd"]
+
+[origin."case(os)".windows."case(host-arch)".x86-64]
+binary = true
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-14.2.0-1/gnat-x86_64-windows64-14.2.0-1.tar.gz"
+hashes = ["sha256:2540cccb78a6e36336bbae2a171e30d764955c6984447c09c612c475843fbc7d"]
+
+[origin."case(os)".macos."case(host-arch)".x86-64]
+binary = true
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-14.2.0-1/gnat-x86_64-darwin-14.2.0-1.tar.gz"
+hashes = ["sha256:bfef513a8f7f665563c1e64046083e52dfd90aa63665bb2248fac293d0ef841e"]
+
+[origin."case(os)".macos."case(host-arch)".aarch64]
+binary = true
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-14.2.0-1/gnat-aarch64-darwin-14.2.0-1.tar.gz"
+hashes = ["sha256:cc5517d65c2074807c8ae97b671e852ed70e307a457e7acde0a848a9394e31c5"]

--- a/index/gn/gnat_native/gnat_native-15.2.1.toml
+++ b/index/gn/gnat_native/gnat_native-15.2.1.toml
@@ -1,0 +1,51 @@
+name = "gnat_native"
+version = "15.2.1"
+provides = ["gnat=15.2.1"]
+description = "The GNAT Ada compiler - Native"
+maintainers = ["Fabien Chouteau <chouteau@adacore.com>", "César Sagaert <sagaert@adacore.com>"]
+maintainers-logins = ["Fabien-Chouteau", "AldanTanneo"]
+licenses = "GPL-3.0-or-later AND GPL-3.0-or-later WITH GCC-exception-3.1"
+website = "https://github.com/alire-project/GNAT-FSF-builds"
+
+auto-gpr-with = false
+
+[configuration]
+disabled = true
+
+[environment."case(os)".linux]
+PATH.prepend = "${CRATE_ROOT}/bin"
+LIBRARY_PATH.prepend = "${CRATE_ROOT}/lib64"
+LD_LIBRARY_PATH.prepend = "${CRATE_ROOT}/lib64"
+LD_RUN_PATH.prepend = "${CRATE_ROOT}/lib64"
+
+[environment."case(os)".windows."case(host-arch)".x86-64]
+PATH.prepend = "${CRATE_ROOT}/bin"
+LIBRARY_PATH.prepend = "${CRATE_ROOT}/lib"
+LD_LIBRARY_PATH.prepend = "${CRATE_ROOT}/lib"
+LD_RUN_PATH.prepend = "${CRATE_ROOT}/lib"
+
+[environment."case(os)".macos]
+PATH.prepend = "${CRATE_ROOT}/bin"
+LIBRARY_PATH.prepend = "${CRATE_ROOT}/lib"
+LD_LIBRARY_PATH.prepend = "${CRATE_ROOT}/lib"
+LD_RUN_PATH.prepend = "${CRATE_ROOT}/lib"
+
+[origin."case(os)".linux."case(host-arch)".x86-64]
+binary = true
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-15.2.0-1/gnat-x86_64-linux-15.2.0-1.tar.gz"
+hashes = ["sha256:4640d4b369833947ab1a156753f4db0ecd44b0f14410b5b2bc2a14df496604bb"]
+
+[origin."case(os)".linux."case(host-arch)".aarch64]
+binary = true
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-15.2.0-1/gnat-aarch64-linux-15.2.0-1.tar.gz"
+hashes = ["sha256:54b1000a1b85f0ec241c71d375bae7602239875a01132f5dc5789a632870a1c7"]
+
+[origin."case(os)".macos."case(host-arch)".x86-64]
+binary = true
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-15.2.0-1/gnat-x86_64-darwin-15.2.0-1.tar.gz"
+hashes = ["sha256:fffe07e8732738a33e6ddc209debc23640e9e629584d30ad8ebee278999c7a0f"]
+
+[origin."case(os)".windows."case(host-arch)".x86-64]
+binary = true
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-15.2.0-1/gnat-x86_64-windows64-15.2.0-1.tar.gz"
+hashes = ["sha256:346e2e00273fecc03bfa333f8e01131d05c8a87e57d4def2c61ae3018744785b"]

--- a/index/gp/gprbuild/gprbuild-21.0.1.toml
+++ b/index/gp/gprbuild/gprbuild-21.0.1.toml
@@ -1,0 +1,25 @@
+name = "gprbuild"
+version = "21.0.1"
+description = "The GPRBuild Ada/multilanguage build tool"
+maintainers = ["chouteau@adacore.com"]
+maintainers-logins = ["Fabien-Chouteau"]
+
+auto-gpr-with = false
+
+[environment]
+PATH.prepend = "${CRATE_ROOT}/bin"
+
+[origin."case(os)".linux."case(host-arch)".x86-64]
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gprbuild-21.0.0-1/gprbuild-x86_64-linux-21.0.0-1.tar.gz"
+hashes = ["sha256:349f6f95165901e9f5099e2046e62fdb2290745a6f984e15e1759f456362d646"]
+binary = true
+
+[origin."case(os)".macos."case(host-arch)".x86-64]
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gprbuild-21.0.0-1/gprbuild-x86_64-darwin-21.0.0-1.tar.gz"
+hashes = ["sha256:0193f1acb608045539f5568e22395007892cb2a44c89fb9eb170293621c66309"]
+binary = true
+
+[origin."case(os)".windows."case(host-arch)".x86-64]
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gprbuild-21.0.0-1/gprbuild-x86_64-windows64-21.0.0-1.tar.gz"
+hashes = ["sha256:c75588476b295107dddcd302b44e9eef86feebcb0c5168518335da6122264c8f"]
+binary = true

--- a/index/gp/gprbuild/gprbuild-21.0.2.toml
+++ b/index/gp/gprbuild/gprbuild-21.0.2.toml
@@ -1,0 +1,25 @@
+name = "gprbuild"
+version = "21.0.2"
+description = "The GPRBuild Ada/multilanguage build tool"
+maintainers = ["chouteau@adacore.com"]
+maintainers-logins = ["Fabien-Chouteau"]
+
+auto-gpr-with = false
+
+[environment]
+PATH.prepend = "${CRATE_ROOT}/bin"
+
+[origin."case(os)".linux."case(host-arch)".x86-64]
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gprbuild-21.0.0-2/gprbuild-x86_64-linux-21.0.0-2.tar.gz"
+hashes = ["sha256:6675f899832a17fdcf4e09ada8844cc519cd5070dca3c9c6b28a7eac6085114e"]
+binary = true
+
+[origin."case(os)".macos."case(host-arch)".x86-64]
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gprbuild-21.0.0-2/gprbuild-x86_64-darwin-21.0.0-2.tar.gz"
+hashes = ["sha256:4f77240c83373412c62f55bda8cbf1136b53e9706dabcaab6c400b52cbadeaf3"]
+binary = true
+
+[origin."case(os)".windows."case(host-arch)".x86-64]
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gprbuild-21.0.0-2/gprbuild-x86_64-windows64-21.0.0-2.tar.gz"
+hashes = ["sha256:9ac7bb44268e0f8d4dcf1666e9ba1aa3d93309f22bd010d352a17575c25fd5d6"]
+binary = true

--- a/index/gp/gprbuild/gprbuild-22.0.1.toml
+++ b/index/gp/gprbuild/gprbuild-22.0.1.toml
@@ -1,0 +1,28 @@
+name = "gprbuild"
+version = "22.0.1"
+description = "The GPRBuild Ada/multilanguage build tool"
+maintainers = ["chouteau@adacore.com"]
+maintainers-logins = ["Fabien-Chouteau"]
+
+auto-gpr-with = false
+
+[environment]
+PATH.prepend = "${CRATE_ROOT}/bin"
+
+[configuration]
+disabled = true
+
+[origin."case(os)".linux."case(host-arch)".x86-64]
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gprbuild-22.0.0-1/gprbuild-x86_64-linux-22.0.0-1.tar.gz"
+hashes = ["sha256:24dfc1b54655edd4f85589e7e7dbd0bee24d087f25d5b0f13d3224fe7acf85b8"]
+binary = true
+
+[origin."case(os)".macos."case(host-arch)".x86-64]
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gprbuild-22.0.0-1/gprbuild-x86_64-darwin-22.0.0-1.tar.gz"
+hashes = ["sha256:b1220e2b24ce8fdb28344ed9c79c81c1fd2e7e3b05839d35167ceda54050def3"]
+binary = true
+
+[origin."case(os)".windows."case(host-arch)".x86-64]
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gprbuild-22.0.0-1/gprbuild-x86_64-windows64-22.0.0-1.tar.gz"
+hashes = ["sha256:c842bbc58b28ad0f1c1f7ba147d59e2c9fc4b8f74355ac734831bc779159b47e"]
+binary = true

--- a/index/gp/gprbuild/gprbuild-24.0.1.toml
+++ b/index/gp/gprbuild/gprbuild-24.0.1.toml
@@ -1,0 +1,23 @@
+name = "gprbuild"
+version = "24.0.1"
+description = "The GPRBuild Ada/multilanguage build tool"
+maintainers = ["chouteau@adacore.com"]
+maintainers-logins = ["Fabien-Chouteau"]
+
+auto-gpr-with = false
+
+[environment]
+PATH.prepend = "${CRATE_ROOT}/bin"
+
+[configuration]
+disabled = true
+
+[origin."case(os)".macos."case(host-arch)".aarch64]
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gprbuild-24.0.0-1/gprbuild-aarch64-darwin-24.0.0-1.tar.gz"
+hashes = ["sha256:6f6b6658f1418f1f43d99f151b8bdcbf1a583dc7cb09348dfec4ca841955ff9c"]
+binary = true
+
+[origin."case(os)".linux."case(host-arch)".aarch64]
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gprbuild-24.0.0-1/gprbuild-aarch64-linux-24.0.0-1.tar.gz"
+hashes = ["sha256:4bcb064c31321f42e6dcadbdff9555f3308c03b4f0f0dd78126220b654eb8196"]
+binary = true

--- a/index/gp/gprbuild/gprbuild-25.0.1.toml
+++ b/index/gp/gprbuild/gprbuild-25.0.1.toml
@@ -1,0 +1,46 @@
+name = "gprbuild"
+version = "25.0.1"
+description = "The GPRBuild Ada/multilanguage build tool"
+maintainers = ["Fabien Chouteau <chouteau@adacore.com>", "César Sagaert <sagaert@adacore.com>"]
+maintainers-logins = ["Fabien-Chouteau", "AldanTanneo"]
+licenses = "GPL-3.0-only WITH GCC-exception-3.1"
+tags = ["gpr", "gprbuild", "tool", "tools", "project"]
+website = "https://docs.adacore.com/gprbuild-docs/html/gprbuild_ug.html"
+
+long-description = """\
+GPRbuild is a generic build tool designed for the construction of large multi-language systems organized into subsystems and libraries.
+It is well-suited for compiled languages supporting separate compilation, such as Ada, C, C++ and Fortran.
+"""
+
+auto-gpr-with = false
+
+[environment]
+PATH.prepend = "${CRATE_ROOT}/bin"
+
+[configuration]
+disabled = true
+
+[origin."case(os)".windows."case(host-arch)".x86-64]
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gprbuild-25.0.0-1/gprbuild-x86_64-windows64-25.0.0-1.tar.gz"
+hashes = ["sha256:1bcdf5e81854baaa293a0661a56b0d842c94c0d3975d7ab4a025e6939a98316a"]
+binary = true
+
+[origin."case(os)".linux."case(host-arch)".x86-64]
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gprbuild-25.0.0-1/gprbuild-x86_64-linux-25.0.0-1.tar.gz"
+hashes = ["sha256:9a2e6cfb9c4add85c7c411e95533c46728aae7de19a9a0b056abf53bd9795b0d"]
+binary = true
+
+[origin."case(os)".linux."case(host-arch)".aarch64]
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gprbuild-25.0.0-1/gprbuild-aarch64-linux-25.0.0-1.tar.gz"
+hashes = ["sha256:5e58c08eb6d0bd15f98654777a53fbb1e4329e38fec7074de08429989850562b"]
+binary = true
+
+[origin."case(os)".macos."case(host-arch)".x86-64]
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gprbuild-25.0.0-1/gprbuild-x86_64-darwin-25.0.0-1.tar.gz"
+hashes = ["sha256:d8b2ccb71236477e099bdff56ec4d3fe8dee03d5f47d9e0b912f0c8ab5826499"]
+binary = true
+
+[origin."case(os)".macos."case(host-arch)".aarch64]
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gprbuild-25.0.0-1/gprbuild-aarch64-darwin-25.0.0-1.tar.gz"
+hashes = ["sha256:c2b4ada4acaec18cb953beeef2153414399302a24b900befe8f90681e207350c"]
+binary = true

--- a/index/gp/gprbuild/gprbuild-external.toml
+++ b/index/gp/gprbuild/gprbuild-external.toml
@@ -1,0 +1,18 @@
+description = "The GPRBuild Ada/multilanguage build tool"
+name = "gprbuild"
+
+maintainers = ["alejandro@mosteo.com"]
+maintainers-logins = ["mosteo"]
+
+[[external]]
+kind = "version-output"
+version-regexp = "^GPRBUILD\\D*([\\d\\.-]+).*"
+version-command = ["gprbuild", "--version"]
+
+# Neither macOS distribution (Homebrew, MacPorts) provides gprbuild.
+[[external]]
+kind = "system"
+[external.origin.'case(os)']
+"freebsd" = ["gprbuild"]
+"linux"   = ["gprbuild"]
+"windows" = ["gprbuild"]

--- a/index/index.toml
+++ b/index/index.toml
@@ -1,1 +1,1 @@
-version = "1.2.1"
+version = "1.4.0"

--- a/scripts/check-website.sh
+++ b/scripts/check-website.sh
@@ -84,6 +84,8 @@ for file in $CHANGES; do
 
    if [[ $website = '' ]] || [[ $website = '""' ]] || [[ $website = null ]]; then
       fail FAILED: crate manifest for $milestone has an empty website field
+   else
+      echo PASSED: website for $milestone: $website
    fi
 
 done

--- a/scripts/check-website.sh
+++ b/scripts/check-website.sh
@@ -74,7 +74,13 @@ for file in $CHANGES; do
       continue
    fi
 
-   website=$(alr --format=json show $milestone | jq .website)
+   # Avoid alr talk about autoupdating interfering
+   alr show $milestone > /dev/null
+
+   output=$(alr --format=json show $milestone 2>&1)
+   echo $output
+
+   website=$(echo $output | jq .website)
 
    if [[ $website = '' ]] || [[ $website = '""' ]] || [[ $website = null ]]; then
       fail FAILED: crate manifest for $milestone has an empty website field

--- a/scripts/check-website.sh
+++ b/scripts/check-website.sh
@@ -40,7 +40,7 @@ alr index --del community || true
 
 for file in $CHANGES; do
 
-   if [[ $file == index.toml ]]; then
+   if [[ $(basename $file) == index.toml ]]; then
       echo Skipping index metadata file: $file
       continue
    fi
@@ -75,7 +75,7 @@ for file in $CHANGES; do
    fi
 
    website=$(alr --format=json show $milestone | jq .website)
-   
+
    if [[ $website = '' ]] || [[ $website = '""' ]] || [[ $website = null ]]; then
       fail FAILED: crate manifest for $milestone has an empty website field
    fi

--- a/scripts/check-website.sh
+++ b/scripts/check-website.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+trap 'echo "ERROR at line ${LINENO} (code: $?)" >&2' ERR
+trap 'echo "Interrupted" >&2 ; exit 1' INT
+
+set -o errexit
+set -o nounset
+
+# Import reusable bits
+pushd $( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+. common.sh
+popd
+
+# Required for aliases to work in non-interactive scripts
+shopt -s expand_aliases
+
+# Ensure all alr runs are non-interactive and able to output unexpected errors
+alias alr="alr -d -n"
+
+# See whats happening
+git log --graph --decorate --pretty=oneline --abbrev-commit --all | head -30
+
+# Detect changes
+CHANGES=$( changed_manifests )
+
+# Bulk changes for the record
+echo Changed files: $CHANGES
+
+# Enable Homebrew on macOS
+[ `uname -s` == "Darwin" ] && {
+   eval $(brew shellenv)
+   echo "Homebrew for macOS enabled"
+}
+
+# Configure local index
+alr index --name local --add ./index
+
+# Remove community index in case it has been added somehow
+alr index --del community || true
+
+for file in $CHANGES; do
+
+   if [[ $file == index.toml ]]; then
+      echo Skipping index metadata file: $file
+      continue
+   fi
+
+   if [[ $file != *.toml ]]; then
+      echo Skipping non-crate file: $file
+      continue
+   fi
+
+   if ! [ -f ./$file ]; then
+      echo Skipping deleted file: $file
+      continue
+   fi
+
+   # Checks passed, this is a crate we must test
+   is_system=false
+
+   crate=$(basename $file .toml | cut -f1 -d-)
+   version=$(basename $file .toml | cut -f2- -d-)
+   milestone="$crate=$version"
+
+   echo
+   box "$milestone"
+   echo
+
+   # Version can be "external", in which case a specific website is
+   # not very useful.
+
+   if [[ $version = external ]]; then
+      echo SKIPPING check for external crate $milestone
+      continue
+   fi
+
+   website=$(alr --format=json show $milestone | jq .website)
+   
+   if [[ $website = '' ]] || [[ $website = '""' ]] || [[ $website = null ]]; then
+      fail FAILED: crate manifest for $milestone has an empty website field
+   fi
+
+done
+
+exit 0

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -67,6 +67,12 @@ function apply_label() {
 
     echo "Applying label $LABEL to PR $PR_NUMBER"
 
+    # If GITHUB_TOKEN is not set, just print instead of applying the label
+    if [[ -z "${GITHUB_TOKEN:-}" ]]; then
+        echo "GITHUB_TOKEN not set, not applying label $LABEL to PR $PR_NUMBER"
+        return
+    fi
+
     # This is more painful that using gh, but gh may not be available in Docker
     # images
 


### PR DESCRIPTION
When publishing a crate without a `website` field, the `alire.ada.dev` website doesn't show anything that can show the origin of the crate. The url from the `[origin]` table is usually not suitable for browsing directly. This makes it hard, when searching for crates, to quickly check the sources or the state of the crate (frequency of updates, etc... ideally the website output would include a history of versions along with dates).

(Maybe Alire could automatically populate the `website` field in its output for the website, when there is for instance a git+https origin?)